### PR TITLE
add custom title-block html partial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 *.DS_Store
-*.html
-*.js
+template.html
 .Rproj.user

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ format:
     epicentre-report-html:
         toc: true
         toc-depth: 3
+        logo1: img/epicentre_msf_logo_transparent.png # top left of header
+        logo2: img/another_logo.png # top right of header
 ```
 
 Alternatively, you can also use the [epitemplates](https://github.com/epicentre-msf/epitemplates) R package from within R/Rstudio.

--- a/_extensions/epitemplates-report/_extension.yml
+++ b/_extensions/epitemplates-report/_extension.yml
@@ -8,10 +8,13 @@ contributes:
         - cosmo
         - css/epicentre_qmd_style.scss
       title-block-banner: true
+      template-partials: 
+        - partials/title-block.html
+      logo1: img/epicentre_msf_logo_transparent.png
       embed-resources: true
       smooth-scroll: true
       code-fold: show
-      code-tools: true
+      code-tools: false
       toc: true
       toc-location: left
       toc-float: true

--- a/_extensions/epitemplates-report/css/epicentre_qmd_style.scss
+++ b/_extensions/epitemplates-report/css/epicentre_qmd_style.scss
@@ -98,6 +98,10 @@ p.subtitle {
   color: darken($col-dark-grey, 50%);
 }
 
+.author {
+  margin-bottom: 0;
+}
+
 /* BLOCKQUOTE */
 .blockquote {
   font-size: 1em;

--- a/_extensions/epitemplates-report/partials/title-block.html
+++ b/_extensions/epitemplates-report/partials/title-block.html
@@ -1,0 +1,49 @@
+<header id="title-block-header" class="container-fluid bg-light py-3">
+  <div class="grid align-items-center">
+    <!-- Left Logo -->
+    <div class="g-col-12 g-col-md-3 p-2 text-center">
+      $if(logo1)$
+      <img src="$logo1$" class="img-fluid" style="max-height: 60px;">
+      $endif$
+    </div>
+
+    <!-- Title and Subtitle in the center -->
+    <div class="g-col-12 g-col-md-6 p-2 text-center">
+      <h1 class="title">$title$</h1>
+      $if(subtitle)$
+      <p class="subtitle">$subtitle$</p>
+      $endif$
+    </div>
+
+    <!-- Right Logo -->
+    <div class="g-col-12 g-col-md-3 p-2 text-center">
+      $if(logo2)$
+      <img src="$logo2$" class="img-fluid" style="max-height: 60px;">
+      $endif$
+    </div>
+  </div>
+</header>
+
+<div class="quarto-title-meta column-body d-flex justify-content-between pb-3">
+
+  $if(author)$
+  <div class="p-2">
+    <div class="quarto-title-meta-heading text-muted">Author</div>
+    <div class="quarto-title-meta-contents">
+      $for(author)$
+      <p class="author">$author$</p>
+      $endfor$
+    </div>
+  </div>
+  $endif$
+
+  $if(date)$
+  <div class="p-2">
+    <div class="quarto-title-meta-heading text-muted">Published</div>
+    <div class="quarto-title-meta-contents">
+      <p class="date">$date$</p>
+    </div>
+  </div>
+  $endif$
+
+</div>

--- a/template.qmd
+++ b/template.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Document title"
-subtitle: EpiDS team - Epicentre, Paris
+subtitle: Epi-DS team - Epicentre, Paris
 footer: Epicentre - Médecins Sans Frontières
 format: 
   epitemplates-report-html: default
@@ -71,7 +71,7 @@ execute:
 
 ::: {.grid}
 
-::: {.g-col-4}
+::: {.g-col-12 .g-col-md-4}
 ```{r, echo = FALSE}
 bslib::value_box(
   title = "Total Screenings",
@@ -83,7 +83,7 @@ bslib::value_box(
 ```
 :::
 
-::: {.g-col-4}
+::: {.g-col-12 .g-col-md-4}
 ```{r, echo = FALSE}
 bslib::value_box(
   title = "Total Enrolments",
@@ -94,7 +94,7 @@ bslib::value_box(
 ```
 :::
 
-::: {.g-col-4}
+::: {.g-col-12 .g-col-md-4}
 ```{r, echo = FALSE}
 bslib::value_box(
   title = "Total Month 2 Visits",


### PR DESCRIPTION
This gives the option to define up to 2 logos to add to the title block header. The first will appear on the top left of the header and the second in the top right. Define like so in the yaml:

```yml
epicentre-report-html:
    logo1: img/epicentre_msf_logo_transparent.png # top left of header
    logo2: img/another_logo.png # top right of header (optional)
```

Also solves the issue of logos overlapping with the title on small screens.

Annoyingly enabling the code-tools options button was messing up the alignment of the title and subtitle so I have disabled it by default for now. I think in most cases we would not want to include this option anyway for reports being published? Zakari actually asked me the other day how to disable it because he was sending a report to the MAGY sponsor and didn't need it in the document.

Let me know if it's working chez vous!